### PR TITLE
feat: move breadcrumbs next to course title

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -8,21 +8,21 @@ export default function Header(props) {
   const { frontendMastersLink } = useContext(CourseContext);
   return (
     <header className="navbar">
-      <h1 className="navbar-brand">
-        <Link href="/">{props.title}</Link>
-      </h1>
-      <div className="navbar-info">
-        {frontendMastersLink ? (
-          <a href={frontendMastersLink} className="cta-btn">
-            Watch on Frontend Masters
-          </a>
-        ) : null}
+      <div className="navbar-location">
+        <h1 className="navbar-brand">
+          <Link href="/">{props.title}</Link>
+        </h1>
         {section ? (
           <h2>
             {section} <i className={`fas fa-${icon}`} /> {title}
           </h2>
         ) : null}
       </div>
+      {frontendMastersLink ? (
+        <a href={frontendMastersLink} className="cta-btn">
+          Watch on Frontend Masters
+        </a>
+      ) : null}
     </header>
   );
 }

--- a/styles/courses.css
+++ b/styles/courses.css
@@ -68,7 +68,7 @@ a {
   text-transform: uppercase;
 }
 
-.navbar-info {
+.navbar-location {
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/styles/courses.css
+++ b/styles/courses.css
@@ -63,7 +63,6 @@ a {
 .navbar h2 {
   font-size: 14px;
   margin: inherit;
-  margin-left: 15px;
   padding: inherit;
   text-transform: uppercase;
 }
@@ -73,6 +72,7 @@ a {
   flex-direction: row;
   align-items: center;
   justify-content: center;
+  padding: 6px;
 }
 
 header .cta-btn {


### PR DESCRIPTION
## Problem
At the moment breadcrumbs are after external link (to Frontend Masters).  

Perhaps they would be better next to title.
That way they will form one message for the user:
"you are here: course title, section, lesson"

(breadcrumbs have more relation with title than external link)

## Before
<img width="1124" alt="breadcrumbs-before" src="https://github.com/user-attachments/assets/3c8d2e0b-6de9-48fd-8743-d04a934b0985" />

## After
<img width="1125" alt="Screenshot 2024-12-11 at 22 44 39" src="https://github.com/user-attachments/assets/f91571c5-b550-4fca-bf5a-e99dcd7f7550" />
