### PR TITLE
Copy code functionality

### DIFF
--- a/data/copyCode.js
+++ b/data/copyCode.js
@@ -1,0 +1,37 @@
+function createDOMElements() {
+  const container = document.createElement("div");
+  container.innerHTML = "<div class='tooltip-copy'><input type='submit' value='Copy' /></div>";
+  container.className = "div-copy";
+  return container;
+}
+
+function attachCopyCodeFunctionality(div) {
+  const elementsToClean = [];
+  document
+      .querySelectorAll("pre")
+      .forEach(function createButtonAndAttachHandlers(pre) {
+        let timeout = null;
+        const copy = div.cloneNode(true);
+        pre.appendChild(copy);
+        elementsToClean.push(pre);
+        pre.onmouseleave = function mouseLeft() {
+          clearTimeout(timeout);
+          copy.classList.remove("clicked");
+        }
+        pre.onclick = function copyTextToClipboard() {
+          navigator.clipboard.writeText(pre.textContent);
+          copy.classList.add("clicked");
+          clearTimeout(timeout);
+          timeout = setTimeout(function hidePopup() {
+            copy.classList.remove("clicked");
+          }, 3000);
+         }
+      });
+
+  return elementsToClean;
+}
+
+export default function createCopyCodeFunctionality() {
+  const container = createDOMElements();
+  return attachCopyCodeFunctionality(container);
+}

--- a/pages/lessons/[section]/[slug].js
+++ b/pages/lessons/[section]/[slug].js
@@ -4,17 +4,23 @@ import { getLesson, getLessons } from "../../../data/lesson";
 import getCourseConfig from "../../../data/course";
 import Corner from "../../../components/corner";
 import { Context } from "../../../context/headerContext";
+import createCopyCodeFunctionality from "../../../data/copyCode";
 
 export default function LessonSlug({ post }) {
   const courseInfo = getCourseConfig();
   const [_, setHeader] = useContext(Context);
+
   useEffect(() => {
     setHeader({
       section: post.section,
       title: post.title,
       icon: post.icon,
     });
-    return () => setHeader({});
+    let elementsToClean = createCopyCodeFunctionality();
+    return () => {
+      setHeader({});
+      elementsToClean = [];
+    }
   }, []);
 
   const title = post.title

--- a/styles/courses.css
+++ b/styles/courses.css
@@ -531,3 +531,52 @@ pre code,
 pre code.hljs {
   display: block;
 }
+
+pre {
+    position: relative;
+}
+
+.div-copy {
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+
+.div-copy .tooltip-copy::after {
+    content: "";
+    position: absolute;
+    right: 100%;
+    margin-right: -4px;
+    top: 60%;
+    transform: translateY(-50%);
+    border-style: solid;
+    border-width: 2px 2px 5px 8px;
+    border-color: transparent transparent transparent #444;
+    opacity: 0;
+    transition: opacity .3s;
+}
+
+.div-copy .tooltip-copy::before {
+  content: "Copied";
+  position: absolute;
+  top: 60%;
+  transform: translateY(-50%);
+  right: 100%;
+  margin-right: 5px;
+  padding: 2px 7px;
+  border-radius: 5px;
+  background: #444;
+  color: #fff;
+  text-align: center;
+  opacity: 0;
+  transition: opacity .3s;
+}
+
+.div-copy .tooltip-copy {
+    margin-right: 0.3em;
+    margin-top: 0.3em;
+}
+
+.div-copy.clicked .tooltip-copy::before, .div-copy.clicked .tooltip-copy::after {
+    opacity: 1;
+}


### PR DESCRIPTION
Adds a button that allows copying to the clipboard a code block.
<img width="586" alt="button" src="https://github.com/user-attachments/assets/d289ac68-8ef6-4dcd-9f18-3bc94e242fa2" />
Tooltip appears when the button is clicked:
<img width="584" alt="tooltip" src="https://github.com/user-attachments/assets/7ad9ef41-b13f-493f-966b-e4fbd4ddc4e2" />
It basically takes [this code](https://github.com/markedjs/marked/blob/19b8ced8ffad1d6e42537984785be02ea9ca9b0e/docs/js/index.js#L27-L54) and "adapts" it.

When the button is clicked a tooltip appears that will fade after 3 seconds (hardcoded value). If the mouse leaves the code
block, the tooltip fades out right await and the 3 seconds timeout is cleared.